### PR TITLE
Add check and resample wav file precision for compatability with autoVOT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Download and set up Praat
         run: |
-          wget https://www.fon.hum.uva.nl/praat/praat6417_linux-intel64-barren.tar.gz -O praat.tar.gz
+          wget https://github.com/praat/praat/releases/download/v6.4.21/praat6421_linux-intel64-barren.tar.gz -O praat.tar.gz
           tar -xvzf praat.tar.gz
 
       - name: Run tests

--- a/conch/analysis/autovot.py
+++ b/conch/analysis/autovot.py
@@ -13,11 +13,16 @@ def is_autovot_friendly_file(sound_file):
     channels = subprocess.run(["soxi", "-c", sound_file], encoding="UTF-8", stdout=subprocess.PIPE).stdout
     if int(channels) != 1:
         return False
+    
+    precision = subprocess.run(["soxi", "-p", sound_file], encoding="UTF-8", stdout=subprocess.PIPE).stdout
+    if int(precision) != 16:
+        return False
+    
     return True
 
 def resample_for_autovot(soundfile, tmpdir):
     output_file = os.path.join(tmpdir, "sound_file.wav")
-    subprocess.call(["sox", soundfile, "-c", "1", "-r", "16000", output_file])
+    subprocess.call(["sox", soundfile, "-c", "1", "-r", "16000", "-b", "16", output_file])
     return output_file
     
 


### PR DESCRIPTION
AutoVOT requires a precision of 16-bit (2 bytes). This check and resample step does not currently exist in conch-sounds when calling autoVOT. 